### PR TITLE
change node engine dependency to at least 4.2.x

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "node-red-contrib-kalman",
   "version": "0.0.3",
   "engines": {
-    "node": "4.2.x"
+    "node": ">=4.2.x"
   },
   "scripts": {
     "start": "node app.js"


### PR DESCRIPTION
The engine dependency on node of version 4.2.x requires exactly that version, even though the package works fine with 9.8.0. NPM doesn't seem to care about it, which is why that issue hasn't come up before, but yarn complains unless "--ignore-engines" is specified.

I changed the dependency to be of "at least version 4.2.x" to make yarn happy. Hope that is fine!